### PR TITLE
Support for altcoins

### DIFF
--- a/protocoin/clients.py
+++ b/protocoin/clients.py
@@ -11,6 +11,8 @@ class BitcoinBasicClient(object):
                    method.
     """
 
+    coin = "bitcoin"
+
     def __init__(self, socket):
         self.socket = socket
         self.buffer = StringIO()
@@ -89,7 +91,7 @@ class BitcoinBasicClient(object):
         :param serializer: The serializar of the message
         """
         bin_data = StringIO()
-        message_header = MessageHeader()
+        message_header = MessageHeader(self.coin)
         message_header_serial = MessageHeaderSerializer()
 
         bin_message = serializer.serialize(message)

--- a/protocoin/fields.py
+++ b/protocoin/fields.py
@@ -11,10 +11,12 @@ PROTOCOL_VERSION = 60002
 
 #: The network magic values
 MAGIC_VALUES = {
-    "main": 0xD9B4BEF9,
-    "testnet": 0xDAB5BFFA,
-    "testnet3": 0x0709110B,
-    "amecoin": 0xFEB4BEF9,
+    "bitcoin":          0xD9B4BEF9,
+    "bitcoin_testnet":  0xDAB5BFFA,
+    "bitcoin_testnet3": 0x0709110B,
+    "namecoin":         0xFEB4BEF9,
+    "litecoin":         0xDBB6C0FB,
+    "litecoin_testnet": 0xDCB7C1FC
 }
 
 #: The available services

--- a/protocoin/serializers.py
+++ b/protocoin/serializers.py
@@ -75,8 +75,8 @@ class Serializer(SerializerABC):
 
 class MessageHeader(object):
     """The header of all bitcoin messages."""
-    def __init__(self):
-        self.magic = fields.MAGIC_VALUES["main"]
+    def __init__(self, coin="bitcoin"):
+        self.magic = fields.MAGIC_VALUES[coin]
         self.command = "None"
         self.length = 0
         self.checksum = 0


### PR DESCRIPTION
This small patch makes it easier to build clients for other altcoins based on protocoin. Here is a sample Litecoin client based on the provided examples:

``` python
import socket
from protocoin.clients import *

class LitecoinClient(BitcoinClient):
    coin = "litecoin"

    def handle_message_header(self, message_header, payload):
        print "Received message:", message_header.command

    def handle_send_message(self, message_header, message):
        print "Message sent:", message_header.command

def run_main():
    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
    sock.connect(("82.27.193.66", 9333))
    client = LitecoinClient(sock)
    client.handshake()
    client.loop()

run_main()
```

To add other altcoins we'd just need to add to the MAGIC_VALUES dict.
