### PR TITLE
added GetBlocks serializer

### DIFF
--- a/protocoin/fields.py
+++ b/protocoin/fields.py
@@ -329,3 +329,19 @@ class Hash(Field):
             bin_data.write(pack_data)
             hash_ >>= 32
         return bin_data.getvalue()
+
+class BlockLocator(Field):
+    """A block locator type used for getblocks and getheaders"""
+    datatype = "<I"
+
+    def parse(self, values):
+        self.values = values
+
+    def serialize(self):
+        bin_data = StringIO()
+        for hash_ in self.values:
+            for i in range(8):
+                pack_data = struct.pack(self.datatype, hash_ & 0xFFFFFFFF)
+                bin_data.write(pack_data)
+                hash_ >>= 32
+        return bin_data.getvalue()

--- a/protocoin/serializers.py
+++ b/protocoin/serializers.py
@@ -519,6 +519,23 @@ class GetAddrSerializer(Serializer):
     """The serializer for the getaddr command."""
     model_class = GetAddr
 
+class GetBlocks(object):
+    """The getblocks command."""
+    command = "getblocks"
+
+    def __init__(self, hashes):
+        self.version = fields.PROTOCOL_VERSION
+        self.hash_count = len(hashes)
+        self.hash_stop = 0
+        self.block_hashes = hashes
+
+class GetBlocksSerializer(Serializer):
+    model_class = GetBlocks
+    version = fields.UInt32LEField()
+    hash_count = fields.VariableIntegerField()
+    block_hashes = fields.BlockLocator()
+    hash_stop = fields.Hash()
+
 
 MESSAGE_MAPPING = {
     "version": VersionSerializer,
@@ -534,4 +551,5 @@ MESSAGE_MAPPING = {
     "headers": HeaderVectorSerializer,
     "mempool": MemPoolSerializer,
     "getaddr": GetAddrSerializer,
+    "getblocks": GetBlocksSerializer,
 }


### PR DESCRIPTION
This allows you to call [getblocks](https://en.bitcoin.it/wiki/Protocol_specification#getblocks).  For instance (extending the ```BitcoinClient``` in the lib):

```python
class Client(BitcoinClient):
    def handle_version(self, message_header, message):
        verack = VerAck()
        self.send_message(verack)
        hashes = [
            int('00000000000000000f69e991ee47a3536770f5d452967ec7edeb8d8cb28f9f28', 16),
            int('000000000000000015bf032f2628e959169f2eea99e56b79152125c753500af6', 16)
        ]
        gb = GetBlocks(hashes)
        self.send_message(gb)

    def handle_inv(self, message_header, message):
        # do something with my getblocks request here

sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
sock.connect(("bitcoin.sipa.be", 8333))
client = Client(sock)
client.handshake()
client.loop()
```