### PR TITLE
Fixed issue with VariableIntegerField unpacking

### DIFF
--- a/protocoin/fields.py
+++ b/protocoin/fields.py
@@ -263,10 +263,10 @@ class VariableIntegerField(Field):
         if int_id == 0xFD:
             data = stream.read(2)
             int_id = struct.unpack("<H", data)[0]
-        if int_id == 0xFE:
+        elif int_id == 0xFE:
             data = stream.read(4)
             int_id = struct.unpack("<I", data)[0]
-        if int_id == 0xFF:
+        elif int_id == 0xFF:
             data = stream.read(8)
             int_id = struct.unpack("<Q", data)[0]
         return int_id

--- a/protocoin/serializers.py
+++ b/protocoin/serializers.py
@@ -395,10 +395,19 @@ class Tx(object):
             text = time.ctime(self.lock_time)
         return text
 
+    def calculate_hash(self):
+        """This method will calculate the hash of the transaction."""
+        hash_fields = ["version", "tx_in", "tx_out", "lock_time"]
+        serializer = TxSerializer()
+        bin_data = serializer.serialize(self, hash_fields)
+        h = hashlib.sha256(bin_data).digest()
+        h = hashlib.sha256(h).digest()
+        return h[::-1].encode("hex_codec")
+
     def __repr__(self):
-        return "<%s Version=[%d] Lock Time=[%s] TxIn Count=[%d] TxOut Count=[%d]>" \
+        return "<%s Version=[%d] Lock Time=[%s] TxIn Count=[%d] Hash=[%s] TxOut Count=[%d]>" \
             % (self.__class__.__name__, self.version, self._locktime_to_text(),
-                len(self.tx_in), len(self.tx_out))
+                len(self.tx_in), self.calculate_hash(), len(self.tx_out))
 
 class TxSerializer(Serializer):
     """The transaction serializer."""


### PR DESCRIPTION
This was an exceptionally nasty bug that only appeared when the int value matched 0xFE/0xFF.

Also added calculate_hash method for transactions.