### PR TITLE
All message objects can now convert themselves to their binary representation

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -24,8 +24,9 @@ name of each message received::
         def handle_message_header(self, message_header, payload):
             print "Received message:", message_header.command
 
-        def handle_send_message(self, message_header, message):
-            print "Message sent:", message_header.command
+        def send_message(self, message):
+	    BitcoinClient.send_message(self, message)
+            print "Message sent:", message.command
 
     def run_main():
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/protocoin/clients.py
+++ b/protocoin/clients.py
@@ -81,14 +81,6 @@ class BitcoinBasicClient(object):
         """
         pass
 
-    def handle_send_message(self, message_header, message):
-        """This method will be called for every sent message.
-
-        :param message_header: The header of the message
-        :param message: The message to be sent
-        """
-        pass
-
     def send_message(self, message):
         """This method will serialize the message using the
         appropriate serializer based on the message command
@@ -96,23 +88,7 @@ class BitcoinBasicClient(object):
 
         :param message: The message object to send
         """
-        bin_data = StringIO()
-        message_header = MessageHeader(self.coin)
-        message_header_serial = MessageHeaderSerializer()
-
-        serializer = MESSAGE_MAPPING[message.command]()
-        bin_message = serializer.serialize(message)
-        payload_checksum = \
-            MessageHeaderSerializer.calc_checksum(bin_message)
-        message_header.checksum = payload_checksum
-        message_header.length = len(bin_message)
-        message_header.command = message.command
-
-        bin_data.write(message_header_serial.serialize(message_header))
-        bin_data.write(bin_message)
-
-        self.socket.sendall(bin_data.getvalue())
-        self.handle_send_message(message_header, message)
+        self.socket.sendall(message.get_message())
 
     def loop(self):
         """This is the main method of the client, it will enter

--- a/protocoin/clients.py
+++ b/protocoin/clients.py
@@ -88,7 +88,7 @@ class BitcoinBasicClient(object):
 
         :param message: The message object to send
         """
-        self.socket.sendall(message.get_message())
+        self.socket.sendall(message.get_message(self.coin))
 
     def loop(self):
         """This is the main method of the client, it will enter

--- a/protocoin/serializers.py
+++ b/protocoin/serializers.py
@@ -76,7 +76,6 @@ class Serializer(SerializerABC):
 class SerializableMessage(object):
     def get_message(self, coin="bitcoin"):
         """Get the binary version of this message, complete with header."""
-        bin_data = StringIO()
         message_header = MessageHeader(coin)
         message_header_serial = MessageHeaderSerializer()
 


### PR DESCRIPTION
This simply removes the code necessary to serialize a message from the connection client to a base ```SerializableMessage``` class.  This means that you can now do something like this:

```python
bin_message = VerAck().get_message()
```

for any of the message types.  This is the final piece necessary to separate the ```socket``` interaction from actual serialization/deserialization.

One note: Part of this does remove the empty ```handle_send_message``` in the ```Client``` class.  This functionality can easily be added to any class that extends the ```Client``` class by just overriding the ```send_message``` method to do whatever used to be done in that method.