### PR TITLE
fixed bug causing ecdsa assertion error on priv -> pubkey generation

### DIFF
--- a/protocoin/keys.py
+++ b/protocoin/keys.py
@@ -28,7 +28,7 @@ class BitcoinPublicKey(object):
         :returns: a new public key
         """
         public_key = private_key.get_verifying_key()
-        hexkey = public_key.to_string().encode("hex")
+        hexkey = (klass.key_prefix + public_key.to_string()).encode("hex")
         return klass(hexkey)
 
     def to_string(self):


### PR DESCRIPTION
These lines:
```python
from protocoin.keys import BitcoinPrivateKey
pk = BitcoinPrivateKey()
pub = pk.generate_public_key()
```
were throwing an ```AssertionError``` from the ```ecdsa``` library because the key prefix wasn't accounted for in the hexkey.