### PR TITLE
Transaction serializer defaults should match what's in the spec

### DIFF
--- a/protocoin/serializers.py
+++ b/protocoin/serializers.py
@@ -341,7 +341,9 @@ class TxIn(object):
     def __init__(self):
         self.previous_output = None
         self.signature_script = "Empty"
-        self.sequence = 0
+        # See https://en.bitcoin.it/wiki/Protocol_specification#tx for definition.
+        # Basically, this field should always be UINT_MAX, i.e. int("ffffffff", 16)
+        self.sequence = 4294967295
 
     def __repr__(self):
         return "<%s Sequence=[%d]>" % \

--- a/protocoin/serializers.py
+++ b/protocoin/serializers.py
@@ -379,7 +379,7 @@ class Tx(object):
     command = "tx"
 
     def __init__(self):
-        self.version = 0
+        self.version = 1
         self.tx_in = []
         self.tx_out = []
         self.lock_time = 0


### PR DESCRIPTION
Per [the tx format docs](https://en.bitcoin.it/wiki/Transaction#general_format_of_a_Bitcoin_transaction_.28inside_a_block.29), the version for a Tx should be 1.  Also, per [the serialization docs](https://en.bitcoin.it/wiki/Protocol_specification#tx), the TxIn sequence should be UINT_MAX.